### PR TITLE
Updated getTasksForCurrentDay() in TaskDAO

### DIFF
--- a/src/brighttime/dal/dao/concretes/TaskDAO.java
+++ b/src/brighttime/dal/dao/concretes/TaskDAO.java
@@ -7,10 +7,12 @@ import brighttime.dal.IConnectionManager;
 import brighttime.dal.dao.interfaces.ITaskDAO;
 import java.io.IOException;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,17 +29,23 @@ public class TaskDAO implements ITaskDAO {
     }
 
     @Override
-    public List<Task> getTasksForCurrentDay() throws DalException {
+    public List<Task> getTasksForCurrentDay(LocalDate date) throws DalException {
         List<Task> tasks = new ArrayList<>();
+
         String sql = "SELECT T.id, T.name, T.dateCreated, T.duration, P.name AS projectName, C.name AS clientName "
                 + "FROM Task AS T "
                 + "JOIN Project AS P "
                 + "ON T.projectId = P.id "
                 + "JOIN Client AS C "
                 + "ON P.clientId = C.id "
-                + "WHERE T.dateCreated = CONVERT(DATE,GETDATE())";
+                + "WHERE T.dateCreated >= ? AND T.dateCreated < ? "
+                + "ORDER BY T.dateCreated DESC";
+
         try (Connection con = connection.getConnection()) {
             PreparedStatement pstmt = con.prepareStatement(sql);
+            pstmt.setDate(1, Date.valueOf(date));
+            pstmt.setDate(2, Date.valueOf(date.plusDays(1)));
+
             ResultSet rs = pstmt.executeQuery();
             while (rs.next()) {
                 int id = rs.getInt("id");

--- a/src/brighttime/dal/dao/interfaces/ITaskDAO.java
+++ b/src/brighttime/dal/dao/interfaces/ITaskDAO.java
@@ -2,6 +2,7 @@ package brighttime.dal.dao.interfaces;
 
 import brighttime.be.Task;
 import brighttime.dal.DalException;
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -13,9 +14,10 @@ public interface ITaskDAO {
     /**
      * Gets the tasks created on the current day.
      *
+     * @param date The current date.
      * @return A list of tasks.
      * @throws brighttime.dal.DalException
      */
-    List<Task> getTasksForCurrentDay() throws DalException;
+    List<Task> getTasksForCurrentDay(LocalDate date) throws DalException;
 
 }


### PR DESCRIPTION
The List<Task> returned is now ordered by desc dateCreated.

The parameter LocalDate has been introduced as it is needed for future upgrades.
